### PR TITLE
Enabled build caching provided by Develocity

### DIFF
--- a/.github/workflows/analyses.yml
+++ b/.github/workflows/analyses.yml
@@ -71,7 +71,7 @@ jobs:
           --activate-profiles staging \
           --activate-profiles ${{ matrix.tool }} \
           --file mq/main \
-          verify \
+          clean verify \
           --projects -packager-opensource \
           --define skipTests=true \
           -Dscan.tag.mq.main

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
         distribution: 'zulu'
         java-version: ${{ matrix.java_version }}
     - name: Test Maven Build
-      run: ./mvnw --show-version --no-transfer-progress --activate-profiles staging --file mq/main install --define build.letter=g --define build.number=${GITHUB_REF_NAME}/${GITHUB_SHA}/${GITHUB_RUN_ID}.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT} -Dscan.tag.mq.main
+      run: ./mvnw --show-version --no-transfer-progress --activate-profiles staging --file mq/main clean install --define build.letter=g --define build.number=${GITHUB_REF_NAME}/${GITHUB_SHA}/${GITHUB_RUN_ID}.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT} -Dscan.tag.mq.main
       env:
         DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
     - name: Upload MQ Distribution
@@ -57,7 +57,7 @@ jobs:
         distribution: 'temurin'
         java-version: 21
     - name: Docs Maven Build
-      run: ./mvnw --show-version --no-transfer-progress --activate-profiles staging --file docs install -Dscan.tag.mq.docs
+      run: ./mvnw --show-version --no-transfer-progress --activate-profiles staging --file docs clean install -Dscan.tag.mq.docs
       env:
         DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
@@ -85,7 +85,7 @@ jobs:
           --define gpg.skip \
           --activate-profiles oss-release \
           -Dscan.tag.mq.main \
-          install
+          clean install
 
   smoke:
     name: Smoke Tests ${{ matrix.mq_command }} @ Java ${{ matrix.java_version }}

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -40,7 +40,7 @@ jobs:
                --define build.number=${GITHUB_REF_NAME}/${GITHUB_SHA}/${GITHUB_RUN_ID}.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT} \
                --file mq/main \
                -Dscan.tag.mq.main \
-               package
+               clean package
     - name: Upload MQ Distribution
       uses: actions/upload-artifact@v3
       with:

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -33,10 +33,10 @@
   </buildScan>
   <buildCache>
     <local>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
     </local>
     <remote>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
       <storeEnabled>#{isTrue(env['CI']) or isTrue(env['JENKINS_URL'])}</storeEnabled>
     </remote>
   </buildCache>


### PR DESCRIPTION
This PR enables [build caching](https://docs.gradle.com/develocity/maven-build-cache/), which will improve both local and CI build times. 

After running Github Actions experiments, we can show that build time for `mvn clean install -f mq/main -Pstaging` with the cache enabled is reduced by 52~%(1m 8ss) from [2m 10s](https://ge.solutions-team.gradle.com/s/fkauza3lgzjag#timeline) (no cache hits) down to [1m 2s](https://ge.solutions-team.gradle.com/s/oy3afkcfptl6q#timeline) (with cache hits) on Github Actions. 

This is related to issue https://github.com/eclipse-ee4j/openmq/issues/2268 and builds on PR https://github.com/eclipse-ee4j/openmq/pull/2269.